### PR TITLE
Add RTG makefile

### DIFF
--- a/benchmarking/makefile
+++ b/benchmarking/makefile
@@ -1,0 +1,129 @@
+download: data/reference/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
+download: data/truth/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG001_GRCh38_1_22_v4.2.1_benchmark.bed
+download: data/truth/HG002_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed
+download: data/truth/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed
+download: data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed
+download: data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG004_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed
+download: data/truth/HG004_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.bed
+download: data/truth/HG006_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG006_GRCh38_1_22_v4.2.1_benchmark.bed
+download: data/truth/HG007_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+download: data/truth/HG007_GRCh38_1_22_v4.2.1_benchmark.bed
+
+# HG001
+data/truth/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv4.2.1/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv4.2.1/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi
+
+data/truth/HG001_GRCh38_1_22_v4.2.1_benchmark.bed:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv4.2.1/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.bed
+
+# HG002
+data/truth/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi
+
+data/truth/HG002_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38/HG002_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed
+
+# HG003
+data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark.vcf.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG003_NA24149_father/NISTv4.2.1/GRCh38/HG003_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG003_NA24149_father/NISTv4.2.1/GRCh38/HG003_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi
+
+data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG003_NA24149_father/NISTv4.2.1/GRCh38/HG003_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed
+
+# HG004
+data/truth/HG004_GRCh38_1_22_v4.2.1_benchmark.vcf.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG004_NA24143_mother/NISTv4.2.1/GRCh38/HG004_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG004_NA24143_mother/NISTv4.2.1/GRCh38/HG004_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi
+
+data/truth/HG004_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG004_NA24143_mother/NISTv4.2.1/GRCh38/HG004_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed
+
+# HG005
+data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.vcf.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv4.2.1/GRCh38/HG005_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv4.2.1/GRCh38/HG005_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi
+
+data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.bed:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv4.2.1/GRCh38/HG005_GRCh38_1_22_v4.2.1_benchmark.bed
+
+# HG006
+data/truth/HG006_GRCh38_1_22_v4.2.1_benchmark.vcf.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG006_NA24694_father/NISTv4.2.1/GRCh38/HG006_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG006_NA24694_father/NISTv4.2.1/GRCh38/HG006_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi
+
+data/truth/HG006_GRCh38_1_22_v4.2.1_benchmark.bed:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG006_NA24694_father/NISTv4.2.1/GRCh38/HG006_GRCh38_1_22_v4.2.1_benchmark.bed
+
+# HG007
+data/truth/HG007_GRCh38_1_22_v4.2.1_benchmark.vcf.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG007_NA24695_mother/NISTv4.2.1/GRCh38/HG007_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG007_NA24695_mother/NISTv4.2.1/GRCh38/HG007_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi
+
+data/truth/HG007_GRCh38_1_22_v4.2.1_benchmark.bed:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG007_NA24695_mother/NISTv4.2.1/GRCh38/HG007_GRCh38_1_22_v4.2.1_benchmark.bed
+
+# hg38
+data/reference/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz:
+	-mkdir -p $(dir $@)
+	wget -P $(dir $@) ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
+
+data/reference/hg38/sdf: data/reference/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
+	rtg format -o $@ data/reference/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
+
+OUTPUT_PATH ?="RTG_OUT"
+
+define RTG_RULE
+$(1): data/reference/hg38/sdf $(2) $(3)
+ifdef QUERY_VCF
+	@echo "QUERY_VCF is set to: ${QUERY_VCF}"
+else
+	@error 'please specify a QUERY_VCF on the command line, e.g., make HG002 QUERY_VCF=/path/to/vcf'
+endif
+ifndef OUTPUT_PATH
+	@echo 'OUTPUT_PATH can be specified on the command line, e.g., make HG002 QUERY_VCF=/path/to/vcf OUTPUT_PATH=/path/to/output'
+endif
+	@echo "OUTPUT_PATH is set to: ${OUTPUT_PATH}"
+
+	@rtg vcfeval \
+		--ref-overlap \
+		-b $(2) \
+		-c ${QUERY_VCF} \
+		-t data/reference/hg38/sdf \
+		-o ${OUTPUT_PATH} \
+		--output-mode annotate \
+		--vcf-score-field QUAL \
+		--bed-regions $(3)
+endef
+
+.ONESHELL:
+$(eval $(call RTG_RULE,HG001,data/truth/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz,data/truth/HG001_GRCh38_1_22_v4.2.1_benchmark.bed))
+$(eval $(call RTG_RULE,HG002,data/truth/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz,data/truth/HG002_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed))
+$(eval $(call RTG_RULE,HG003,data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark.vcf.gz,data/truth/HG003_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed))
+$(eval $(call RTG_RULE,HG004,data/truth/HG004_GRCh38_1_22_v4.2.1_benchmark.vcf.gz,data/truth/HG004_GRCh38_1_22_v4.2.1_benchmark_noinconsistent.bed))
+$(eval $(call RTG_RULE,HG005,data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.vcf.gz,data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.bed))
+$(eval $(call RTG_RULE,HG006,data/truth/HG006_GRCh38_1_22_v4.2.1_benchmark.vcf.gz,data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.bed))
+$(eval $(call RTG_RULE,HG007,data/truth/HG007_GRCh38_1_22_v4.2.1_benchmark.vcf.gz,data/truth/HG005_GRCh38_1_22_v4.2.1_benchmark.bed))


### PR DESCRIPTION
This Makefile automatically:

* downloads the v4.2.1 NIST truths for HG001-HG007.
* downloads the hg38 reference.
* generates the SDF file for the reference.

The makefile defines one rule per sample and can be invoked as `make HG002`.
The input VCF is provided using `QUERY_VCF=/path/to/query/vcf`
The output folder name can be provided using `OUTPUT_PATH=/path/to/output`

Call example: `make HG002 QUERY_VCF=/path/to/query/vcf OUTPUT_PATH=/path/to/output`